### PR TITLE
Add random sorting option to history

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -66,6 +66,11 @@ public class StatisticsPlaylistFragment
     private HistoryRecordManager recordManager;
 
     private List<StreamStatisticsEntry> processResult(final List<StreamStatisticsEntry> results) {
+        if (sortMode == StatisticSortMode.RANDOM) {
+            Collections.shuffle(results);
+            return results;
+        }
+
         final Comparator<StreamStatisticsEntry> comparator;
         switch (sortMode) {
             case LAST_PLAYED:
@@ -302,6 +307,11 @@ public class StatisticsPlaylistFragment
             sortMode = StatisticSortMode.MOST_PLAYED;
             setTitle(getString(R.string.title_most_played));
             headerBinding.sortButtonIcon.setImageResource(R.drawable.ic_history);
+            headerBinding.sortButtonText.setText(R.string.title_random);
+        } else if (sortMode == StatisticSortMode.MOST_PLAYED) {
+            sortMode = StatisticSortMode.RANDOM;
+            setTitle(getString(R.string.title_random));
+            headerBinding.sortButtonIcon.setImageResource(R.drawable.ic_shuffle);
             headerBinding.sortButtonText.setText(R.string.title_last_played);
         } else {
             sortMode = StatisticSortMode.LAST_PLAYED;
@@ -387,6 +397,7 @@ public class StatisticsPlaylistFragment
     private enum StatisticSortMode {
         LAST_PLAYED,
         MOST_PLAYED,
+        RANDOM,
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,6 +391,7 @@
     <string name="delete_item_search_history">Do you want to delete this item from search history?</string>
     <string name="title_last_played">Last Played</string>
     <string name="title_most_played">Most Played</string>
+    <string name="title_random">Random</string>
     <!-- Content -->
     <string name="main_page_content">Content of main page</string>
     <string name="main_page_content_summary">What tabs are shown on the main page</string>


### PR DESCRIPTION
## Summary
- add `RANDOM` option in `StatisticSortMode`
- shuffle entries when random mode is chosen
- show shuffle icon and text when cycling sorting mode
- add new string `title_random`

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531fbe6f588320a91ce78d07eea761