### PR TITLE
Add random sort mode

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -66,6 +66,11 @@ public class StatisticsPlaylistFragment
     private HistoryRecordManager recordManager;
 
     private List<StreamStatisticsEntry> processResult(final List<StreamStatisticsEntry> results) {
+        if (sortMode == StatisticSortMode.RANDOM) {
+            Collections.shuffle(results);
+            return results;
+        }
+
         final Comparator<StreamStatisticsEntry> comparator;
         switch (sortMode) {
             case LAST_PLAYED:
@@ -75,7 +80,7 @@ public class StatisticsPlaylistFragment
                 comparator = Comparator.comparingLong(StreamStatisticsEntry::getWatchCount);
                 break;
             default:
-                return null;
+                return results;
         }
         Collections.sort(results, comparator.reversed());
         return results;
@@ -387,6 +392,7 @@ public class StatisticsPlaylistFragment
     private enum StatisticSortMode {
         LAST_PLAYED,
         MOST_PLAYED,
+        RANDOM,
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,6 +391,7 @@
     <string name="delete_item_search_history">Do you want to delete this item from search history?</string>
     <string name="title_last_played">Last Played</string>
     <string name="title_most_played">Most Played</string>
+    <string name="title_random">Random Order</string>
     <!-- Content -->
     <string name="main_page_content">Content of main page</string>
     <string name="main_page_content_summary">What tabs are shown on the main page</string>


### PR DESCRIPTION
## Summary
- implement new RANDOM mode for `StatisticsPlaylistFragment`
- expose random mode string resource

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531fbe6f588320a91ce78d07eea761